### PR TITLE
CKLR nextblock_incr

### DIFF
--- a/cklr/CKLR.v
+++ b/cklr/CKLR.v
@@ -167,6 +167,12 @@ Record cklr :=
       Mem.perm m2 b2 ofs2 k p ->
       Mem.perm m1 b1 ofs1 k p \/ ~Mem.perm m1 b1 ofs1 Max Nonempty;
 
+    cklr_nextblock_incr w m1 m2 m1' m2':
+      match_mem w m1 m2 ->
+      (<> match_mem)%klr w m1' m2' ->
+      Ple (Mem.nextblock m1) (Mem.nextblock m1') ->
+      Ple (Mem.nextblock m2) (Mem.nextblock m2');
+
   }.
 
 Global Existing Instance cklr_kf.

--- a/cklr/CKLRAlgebra.v
+++ b/cklr/CKLRAlgebra.v
@@ -543,6 +543,17 @@ Next Obligation. (* perm inv *)
   - right. intros Hm1. apply H. revert Hm1. rauto.
 Qed.
 
+Next Obligation. (* nextblock incr*)
+  destruct H as (mI & Hm1I & Hm2I).
+  destruct H0 as ([w' w0'] & Hw' & mI' & Hm1I' & Hm2I').
+  cbn [fst snd] in *. unfold Ple in *.
+  eapply cklr_nextblock_incr. apply Hm2I.
+  eexists. split. apply Hw'. apply Hm2I'.
+  eapply cklr_nextblock_incr. apply Hm1I.
+  eexists. split. apply Hw'. apply Hm1I'.
+  auto.
+Qed.
+  
 Bind Scope cklr_scope with cklr.
 Delimit Scope cklr_scope with cklr.
 Infix "@" := cklr_compose (at level 30, right associativity) : cklr_scope.

--- a/cklr/Extends.v
+++ b/cklr/Extends.v
@@ -183,6 +183,10 @@ Next Obligation.
   eapply Mem.perm_extends_inv; eauto.
 Qed.
 
+Next Obligation.
+  destruct H0 as (?&?&?).
+  inv H. inv H2. congruence.
+Qed.
 
 (** * Useful lemmas *)
 

--- a/cklr/Inject.v
+++ b/cklr/Inject.v
@@ -135,7 +135,13 @@ Next Obligation.
   destruct H. inv H0; cbn in *. xomega.
 Qed.
 
-Next Obligation. (* Mem.alloc *)
+Instance inj_cklr_kf: KripkeFrame unit inj_world.
+split. intro. exact inj_incr.
+Defined.
+
+Lemma inj_cklr_alloc:
+    Monotonic Mem.alloc (|= inj_mem ++> - ==> - ==> (<> inj_mem * block_inject_sameofs @@ [injw_meminj])).
+Proof.
   intros [f nb1 nb2] m1 m2 Hm lo hi. cbn in *. inv Hm.
   destruct (Mem.alloc m1 lo hi) as [m1' b1] eqn:Hm1'.
   edestruct Mem.alloc_parallel_inject
@@ -155,6 +161,10 @@ Next Obligation. (* Mem.alloc *)
     + erewrite (Mem.nextblock_alloc m2 _ _ m2'); eauto. xomega.
   - econstructor; eauto; erewrite Mem.nextblock_alloc by eauto; xomega.
   - cbn. red. auto.
+Qed.
+
+Next Obligation. (* Mem.alloc *)
+  exact inj_cklr_alloc.
 Qed.
 
 Next Obligation. (* Mem.free *)
@@ -271,6 +281,26 @@ Next Obligation. (* perm_inv *)
   inv H0.
   eapply Mem.perm_inject_inv; eauto.
 Qed.
+
+Lemma nextblock_inject:
+  Monotonic
+    Mem.nextblock
+    (|= Mem.inject ++> (<> block_inject_sameofs)).
+Admitted.
+
+Next Obligation. (* nextblock incr *)
+  (* inv H. destruct H0 as (w' & Hw' & Hm'). inv Hm'. *)
+  (* remember (Mem.alloc m1' 0 0) as mb eqn: Hmb1. destruct mb as [m1'' b1]. *)
+  (* remember (Mem.alloc m2' 0 0) as mb eqn: Hmb2. destruct mb as [m2'' b2]. *)
+  (* exploit Mem.alloc_result. symmetry. apply Hmb1. intros Hnb1. *)
+  (* exploit Mem.alloc_result. symmetry. apply Hmb2. intros Hnb2. *)
+  inversion H as [? ? ? Hm]. subst. clear H.
+  destruct H0 as (w' & Hw' & Hm').
+  (* edestruct inj_cklr_alloc as (w'' & Hw'' & Hm''). apply Hm'. *)
+  (* rewrite <- Hmb1 in Hm''. rewrite <- Hmb2 in Hm''. *)
+  exploit nextblock_inject. apply Hm. intros Hb.
+  unfold Ple in *. rewrite Pos.le_nlt in *.
+  
 
 (** * Useful theorems *)
 

--- a/cklr/Inject.v
+++ b/cklr/Inject.v
@@ -311,7 +311,7 @@ Next Obligation. (* nextblock incr *)
   unfold Ple in *. rewrite Pos.le_nlt in *.
   exploit inj_acc_separated;
     [ apply H
-    | cbn in *; eapply PreOrder_Transitive; eauto
+    | cbn in *; etransitivity; eauto
     | eapply Mem.mi_freeblocks;[ apply Hm | apply H1 ]
     | apply Hb
     | ].

--- a/cklr/InjectFootprint.v
+++ b/cklr/InjectFootprint.v
@@ -365,6 +365,18 @@ Next Obligation.
   eapply Mem.perm_inject_inv; eauto.
 Qed.
 
+Next Obligation.
+  inv H. eapply (cklr_nextblock_incr inj); eauto.
+  constructor. apply Hm.
+  destruct H0 as (w' & Hw' & Hm'). inv Hm'. inv Hw'.
+  eexists. split. constructor.
+  - eauto.
+  - intros. do 2 rewrite Pos.le_nlt. eapply H11; eauto.
+  - inv H8. apply unchanged_on_nextblock.
+  - inv H9. apply unchanged_on_nextblock.
+  - constructor. auto.
+Qed.
+
 
 (** * Properties *)
 

--- a/cklr/VAExtends.v
+++ b/cklr/VAExtends.v
@@ -523,6 +523,11 @@ Next Obligation.
   eapply Mem.mext_perm_inv in H1; eauto.
 Qed.
 
+(** nextblock incr *)
+Next Obligation.
+  inv H. destruct H0 as (?&?&?).
+  inv H0. inv H7. inv H10. congruence.
+Qed.
 
 (** * Other properties *)
 

--- a/cklr/VAInject.v
+++ b/cklr/VAInject.v
@@ -188,6 +188,11 @@ Next Obligation.
   inv H. eapply (cklr_perm_inv inj); eauto.
 Qed.
 
+Next Obligation.
+  inv H. eapply (cklr_nextblock_incr inj); eauto.
+  destruct H0 as (w' & Hw' & Hm). inv Hm.
+  eexists. split. apply Hw'. auto.
+Qed.
 
 (** * Correspondance with [vamatch] *)
 


### PR DESCRIPTION
I refactored the proof in `Inject.v` a bit because I wanted to reuse the proof from `cklr_alloc` and `mi_acc_separated`. Let me know if there is a better way to do that. And you may want to squash the commits since they are not that meaningful.